### PR TITLE
Make `global_factory` a `GeometryFactory::Ptr`

### DIFF
--- a/c/Shapes.cc
+++ b/c/Shapes.cc
@@ -56,14 +56,14 @@ using namespace geos::geom;
 using namespace SpatialIndex;
 
 void init_geos() {
-  if (global_factory != NULL) return;
+  if (global_factory != nullptr) return;
 
   // define a precision model that just uses double precision floating points.
   PrecisionModel *pm = new PrecisionModel(geos::geom::PrecisionModel::FLOATING);
 
   // Initialize global factory with defined PrecisionModel
   // and a SRID of -1 (undefined).
-  global_factory = new GeometryFactory(pm, -1);
+  global_factory = GeometryFactory::create(pm, -1);
 
   // We do not need PrecisionMode object anymore, it has
   // been copied to global_factory private storage
@@ -72,9 +72,9 @@ void init_geos() {
 }
 
 void cleanup_geos() {
-  if (global_factory != NULL) {
-    delete global_factory;
-    global_factory = NULL;
+  if (global_factory != nullptr) {
+    // Smart pointer - 
+    global_factory = nullptr;
   }
 }
 

--- a/c/globals.cc
+++ b/c/globals.cc
@@ -1,4 +1,3 @@
 #include "globals.h"
 
-geos::geom::GeometryFactory* global_factory = NULL;
-
+geos::geom::GeometryFactory::Ptr global_factory = nullptr;

--- a/c/globals.h
+++ b/c/globals.h
@@ -60,6 +60,6 @@ static PlAtom ATOM_haversine("haversine");
 static PlAtom ATOM_memory("memory");
 static PlAtom ATOM_disk("disk");
     
-extern geos::geom::GeometryFactory *global_factory;
+extern geos::geom::GeometryFactory::Ptr global_factory;
 
 #endif // __GLOBALS_H

--- a/c/space.cc
+++ b/c/space.cc
@@ -57,7 +57,6 @@
 #define INIT_LOCK(lock)			init_lock(lock)
 
 
-extern geos::geom::GeometryFactory* global_factory;
 map<atom_t,Index*> index_map;
 rwlock index_map_lock;
 
@@ -536,7 +535,7 @@ create_square_linearring(double xoffset, double yoffset, double side) {
   cl->add(Coordinate(xoffset+side, yoffset));
   cl->add(Coordinate(xoffset, yoffset));
   PrecisionModel *pm = new PrecisionModel(geos::geom::PrecisionModel::FLOATING);
-  GeometryFactory *global_factory = new GeometryFactory(pm, -1);
+  GeometryFactory::Ptr global_factory = GeometryFactory::create(pm, -1);
   LinearRing *lr = global_factory->createLinearRing(cl);
   return lr;
 }
@@ -549,7 +548,7 @@ create_square_polygon(double xoffset, double yoffset, double side) {
   vector<Geometry *> *holes = new vector<Geometry *>;
   holes->push_back((Geometry*)inner);
   PrecisionModel *pm = new PrecisionModel(geos::geom::PrecisionModel::FLOATING);
-  GeometryFactory *global_factory = new GeometryFactory(pm, -1);
+  GeometryFactory::Ptr global_factory = GeometryFactory::create(pm, -1);
   geos::geom::Polygon *poly = global_factory->createPolygon(outer, holes);
   return poly;
 }

--- a/pack.pl
+++ b/pack.pl
@@ -1,5 +1,5 @@
 name(space).
-version('0.2').
+version('0.3').
 title('Space package').
 keywords(['geo', 'spatial']).
 author( 'Willem van Hage', 'w.vanhage@esciencecenter.nl' ).


### PR DESCRIPTION
Fixes geom to support builds with more recent dependencies, specifically libspatialindex-c5 on Debian Buster.