### PR TITLE
Minor cleanup + modernise configure.ac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Makefile
 autom4te.cache
 buildenv.sh
+status.db
 *.o
 config.status
 configure

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,26 +6,34 @@
 
 SOBJ=	$(SWIPL_MODULE_DIR)/space.$(SWIPL_MODULE_EXT)
 LIBS=	@LIBS@
-CXX=	@CXX@
-LD=	@CXX@
+CXX?=	@CXX@
+LD?=	@CXX@
 OBJ=    c/space.o c/globals.o c/Index.o c/Search.o \
         c/Shapes.o c/lock.o c/debug.o
-SWIPL_CFLAGS+=-I. -std=c++17 -O2 -g  # -gdwarf-2 -g3
+SWIPL_CFLAGS+=-I. -std=c++17 -O2 -g # -gdwarf-2 -g3
+CXX?=$(SWIPL_CXX)
+LD?=$(SWIPL_CXX)
+
+# The following should be set by buildenv.sh:
+SWIPL?=swipl
 
 all:	$(SOBJ)
 
 $(SOBJ): $(OBJ)
 	mkdir -p $(SWIPL_MODULE_DIR)
-	$(SWIPL_LD) $(SWIPL_MODULE_LDFLAGS) -o $@ $(OBJ) $(LIBS) $(SWIPL_MODULE_LIB)
+	$(CXX) $(SWIPL_MODULE_LDFLAGS) -o $@ $(OBJ) $(LIBS) $(SWIPL_MODULE_LIB)
 
 .cc.o:
-	$(SWIPL_CXX) $(CPPFLAGS) $(COFLAGS) $(SWIPL_CFLAGS) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(COFLAGS) $(SWIPL_CFLAGS) -c -o $@ $<
 
 check::
 	$(SWIPL) -g test_space -t halt test/test_space.pl
 
 install::
 clean:
-	$(RM) c/*.o *~ Makefile
+	$(RM) c/*.o *~ Makefile # TODO: status.db buildenv.sh
+	$(RM) -r autom4te.cache config.h config.h.in config.log config.status configure lib
+
 distclean: clean
 	$(RM) $(SOBJ)
+	@# git clean -dxf

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ sources.
   - libgeos
   - libspatialindex
 
-On recent Debian versions (_bullseye_) these may be installed using
+On recent Debian versions (_bullseye_ or _bookworm_) these may be installed using
 
-    apt-get install libspatialindex-dev libgeos-dev libgeos++-dev libserd-dev
+    apt install libspatialindex-dev libgeos-dev libgeos++-dev libserd-dev
+
+The pack has been built and tested with libgeos++-dev 3.11.1 and might
+not work with other releases (the C++ interface is documented as being
+"unstable"). The symptom of incompatibility is that the pack install
+fails with C++ compilation errors.

--- a/c/space.cc
+++ b/c/space.cc
@@ -57,6 +57,7 @@
 #define INIT_LOCK(lock)			init_lock(lock)
 
 
+// TODO: use SWI-cpp2-atommap.h
 map<atom_t,Index*> index_map;
 rwlock index_map_lock;
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,28 +1,30 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT(pack.pl)
-AC_PREREQ([2.50])
-AC_CONFIG_HEADER(config.h)
+AC_INIT
+AC_CONFIG_SRCDIR([pack.pl])
+AC_PREREQ([2.71])
+AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CXX
-AC_LANG_CPLUSPLUS
+AC_LANG([C++])
 
 AC_CHECK_LIB(geos, main)
 AC_CHECK_LIB(spatialindex, main)
 
 AC_CHECK_HEADERS(spatialindex/SpatialIndex.h,[si=1],[si=0])
 if test "$si" = 0; then
-   AC_ERROR("Cannot find spatialindex. Spatialindex must be installed first (http://trac.gispython.org/spatialindex/)")
+   AC_MSG_ERROR("Cannot find spatialindex. Spatialindex must be installed first (http://trac.gispython.org/spatialindex/)")
 fi
 
 AC_CHECK_HEADERS(geos_c.h,[geos=1],[geos=0])
 if test "$geos" = 0; then
-   AC_ERROR("Cannot find GEOS library. GEOS must be installed first (http://trac.osgeo.org/geos/)")
+   AC_MSG_ERROR("Cannot find GEOS library. GEOS must be installed first (http://trac.osgeo.org/geos/)")
 fi
 
 AC_CHECK_FUNCS(bzero)
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
 
 
 

--- a/pack.pl
+++ b/pack.pl
@@ -8,4 +8,6 @@ maintainer( 'Jan Wielemaker', 'J.Wielemaker@vu.nl' ).
 home( 'https://github.com/JanWielemaker/space.git' ).
 download( 'https://github.com/JanWielemaker/space/archive/V*.zip' ).
 pack_version(2).
-% prolog_version('9.3.8').
+% requires(prolog >= "9.3.8"). % TODO: stable version
+requires(prolog:c_cxx(_)).
+


### PR DESCRIPTION
Nobody has responded to https://swi-prolog.discourse.group/t/future-of-the-space-package/7622/ , so don't plan on doing any more work on this package unless requested. There are quite a few places where, e.g. `term_t` is used instead of `PlTerm` (also, things like `qid_t` instead of `PlQuery`), but changing them is error-prone, and there is a lack of test cases.

As with pack `hdt`, I assume that @JanWielemaker will do the necessary things to update https://www.swi-prolog.org/pack/list?p=space ... also, there probably need to be some tweaks to `pack.pl`.